### PR TITLE
Add Section 8.4 Resolver Observability and bump spec to v0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ You'll get inline field validation and error reporting as you author Bouncer fil
 
 ```
 bouncer-md/
-├── SPEC.md                               # The Bouncer specification (v0.5)
+├── SPEC.md                               # The Bouncer specification (v0.7)
 ├── bouncer-frontmatter.schema.json       # JSON Schema for frontmatter validation
 ├── examples/
 │   ├── default.bouncer.md                # Baseline example with multiple controls
@@ -225,13 +225,13 @@ Contributions welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 The full specification is in [SPEC.md](./SPEC.md).
 
-Current version: **v0.5**
+Current version: **v0.7**
 
 ---
 
 ## Ecosystem
 
-Bouncer is designed to complement agent observability standards. Bouncer defines what rules exist and when they fire. [OpenTelemetry GenAI Semantic Conventions](https://github.com/open-telemetry/semantic-conventions) define whether they fired and what happened.
+Bouncer is designed to complement agent observability standards. Bouncer defines what rules exist and when they fire. [SPEC.md Section 8.4](./SPEC.md) defines the normative telemetry model — the span and log event structure resolvers should emit so that observability layers, including [OpenTelemetry GenAI Semantic Conventions](https://github.com/open-telemetry/semantic-conventions), can surface whether guardrails fired and what happened.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is not an agent instruction file. It is not a skill. It is not a prompt templ
 
 Bouncer is **safety and compliance only** — a clear separation that makes guardrails reusable, auditable, and portable across any agent framework or runtime.
 
-```
+```text
 agent.md     → behavior
 skill.md     → capabilities
 bouncer.md   → guardrails  ← this is Bouncer
@@ -129,13 +129,13 @@ cp examples/default.bouncer.md ./bouncer.md
 
 ## VS Code Validation
 
-**1. Install the YAML extension**
+### 1. Install the YAML extension
 
 [Install redhat.vscode-yaml](vscode:extension/redhat.vscode-yaml) — or search `redhat.vscode-yaml` in the VS Code Extensions panel.
 
-Marketplace page: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
+Marketplace page: [redhat.vscode-yaml](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
 
-**2. Add schema wiring to `.vscode/settings.json`**
+### 2. Add schema wiring to `.vscode/settings.json`
 
 ```json
 {
@@ -154,7 +154,7 @@ You'll get inline field validation and error reporting as you author Bouncer fil
 
 ## Repository Structure
 
-```
+```text
 bouncer-md/
 ├── SPEC.md                               # The Bouncer specification (v0.7)
 ├── bouncer-frontmatter.schema.json       # JSON Schema for frontmatter validation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -125,7 +125,7 @@ Understanding the security properties of bouncer-md requires understanding what 
 **Affected path:** Path A and Path B.
 
 **Mitigation:**
-- Pin your resolver implementation to a specific tagged release of the canonical spec (e.g. `v0.5`).
+- Pin your resolver implementation to a specific tagged release of the canonical spec (e.g. `v0.7`).
 - Verify the pinned version in your CI pipeline against the Section 11.3 conformance tests.
 - Treat any resolver not pinned to a canonical tagged release as unverified.
 - Use the optional `spec` frontmatter anchor (Section 3.3 of the spec) to declare which spec version a file was authored against. If a resolver detects a mismatch, it SHOULD log it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,7 @@ Understanding the security properties of bouncer-md requires understanding what 
 **Affected path:** Path A and Path B.
 
 **Mitigation:**
+
 - Security through obscurity is not a viable alternative. The resolver is the correct mitigation.
 - Path B deterministic enforcement removes LLM interpretation from the enforcement loop. An attacker knowing the vocabulary does not help them bypass a programmatic resolver.
 - Add domain-specific adversarial test cases beyond the public test suite. The public suite in `tests/adversarial/` establishes a baseline — it should not be your entire coverage.
@@ -30,6 +31,7 @@ Understanding the security properties of bouncer-md requires understanding what 
 **Affected path:** Path A only.
 
 **Mitigation:**
+
 - This is a documented and accepted limitation of Path A. Controls are instructions, not guarantees.
 - Include the preamble in both the bouncer file and the agent instruction file (Option 3 in Section 5.2.1 of the spec) for defense in depth.
 - For compliance-sensitive or production deployments, use Path B.
@@ -44,6 +46,7 @@ Understanding the security properties of bouncer-md requires understanding what 
 **Affected path:** Path A and Path B.
 
 **Mitigation:**
+
 - Treat `bouncer.md` as a security artifact. It belongs in version control and should be subject to code review the same way security configurations are reviewed.
 - Use the test suite to validate baseline controls before merging changes to `bouncer.md`.
 - For regulated environments, require sign-off on baseline policy changes from a security or compliance owner.
@@ -57,6 +60,7 @@ Understanding the security properties of bouncer-md requires understanding what 
 **Affected path:** Path B only.
 
 **Mitigation:**
+
 - Treat the resolver as security-critical middleware. Apply the same review and testing standards you would to an authentication library.
 - Emit resolver decisions to your observability pipeline. Every control evaluation — pass or block — should produce a telemetry event. Absence of events is itself a signal.
 - Periodically validate resolver behavior against the test suite in production, not just at build time.
@@ -71,6 +75,7 @@ Understanding the security properties of bouncer-md requires understanding what 
 **Affected path:** Path B only.
 
 **Mitigation:**
+
 - Resolver file discovery scope **MUST** be explicitly configured to trusted, version-controlled paths only.
 - Never load bouncer files from locations that can be written to by untrusted parties.
 - Validate the integrity of bouncer files at load time — hash verification against a known-good manifest is recommended for production deployments.
@@ -84,6 +89,7 @@ Understanding the security properties of bouncer-md requires understanding what 
 **Affected path:** Path A and Path B.
 
 **Mitigation:**
+
 - The public test suite establishes a baseline floor, not a ceiling.
 - Teams **SHOULD** maintain a private adversarial test suite covering the specific threat surface of their deployment.
 - Rotate and extend adversarial inputs over time. A static test suite becomes less effective as attackers adapt.
@@ -97,6 +103,7 @@ Understanding the security properties of bouncer-md requires understanding what 
 **Affected path:** Path A only.
 
 **Mitigation:**
+
 - Keep bouncer files focused and concise. A 500-line bouncer file is a red flag.
 - Place the bouncer file reference early in your agent instruction file, not at the end.
 - Use `priority: immutable` on critical controls to signal their importance explicitly.
@@ -111,6 +118,7 @@ Understanding the security properties of bouncer-md requires understanding what 
 **Affected path:** Hybrid (Path A + Path B).
 
 **Mitigation:**
+
 - Hybrid deployments MUST document which controls are Path B enforced (deterministic) vs Path A best-effort (alignment-dependent). See Section 8.3 of the spec.
 - Never represent alignment-dependent enforcement as a guarantee.
 - When the resolver is unavailable and Path A fallback activates, treat the session as reduced-guarantee and log it.
@@ -125,6 +133,7 @@ Understanding the security properties of bouncer-md requires understanding what 
 **Affected path:** Path A and Path B.
 
 **Mitigation:**
+
 - Pin your resolver implementation to a specific tagged release of the canonical spec (e.g. `v0.7`).
 - Verify the pinned version in your CI pipeline against the Section 11.3 conformance tests.
 - Treat any resolver not pinned to a canonical tagged release as unverified.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,4 +1,4 @@
-# Bouncer Specification v0.5
+# Bouncer Specification v0.7
 
 *A framework-agnostic guardrail and trust policy specification for agentic systems*
 
@@ -256,6 +256,7 @@ Resolver capability requirement for `log`:
 * Resolvers that support `log` **MUST** implement a logging mechanism and **MUST** document that they do so
 * If a resolver does not implement logging, `log` outcomes are silently no-ops — this **MUST** be documented by the resolver
 * Authors **SHOULD NOT** rely on `log` for audit compliance unless the resolver explicitly declares logging support
+* When `log` fires, resolvers **SHOULD** emit a `bouncer.guardrail.fired` log event per the model defined in Section 8.4
 
 #### Capability Fallback
 
@@ -592,6 +593,90 @@ Hybrid deployments **MUST NOT** represent any Path A-enforced control as determi
 
 ---
 
+### 8.4 Resolver Observability
+
+Resolvers **SHOULD** emit structured telemetry to make guardrail behavior visible to operators. This section defines the normative span model, log event model, and attribute namespace for resolver telemetry.
+
+#### Span model
+
+One span **MUST** be emitted per resolver invocation.
+
+**Span name:** `bouncer.resolve`
+
+**Span kind:** `INTERNAL`
+
+**Required attributes:**
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `bouncer.policy.file` | string | Path or identifier of the bouncer file evaluated |
+| `bouncer.policy.version` | string | Version of the policy file itself (from `version` frontmatter field if present) |
+| `bouncer.policy.spec` | string | Spec URI the file was authored against (from `spec` frontmatter field if present) |
+| `bouncer.decision` | string enum | `allow`, `block`, `redact`, `require_confirmation` |
+| `bouncer.execution_point` | string enum | Where in the pipeline the resolver fired — **MUST** be one of: `pre_invocation`, `tool_call`, `agent_handoff`, `post_generation` |
+
+`bouncer.execution_point` is a **normative closed enumeration** in v0.7. Resolvers **MUST NOT** emit values outside this set. Future versions of the spec may extend the set; resolvers **SHOULD** be designed so that adding a new value requires only a string change.
+
+**Optional attributes (populated on guardrail firing):**
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `bouncer.rule.name` | string | Human-readable control name that triggered |
+| `bouncer.rule.subject` | string | Subject that matched (e.g. `user_input`, `tool_result`) |
+| `bouncer.rule.condition` | string | Condition that matched (e.g. `prompt_injection`) |
+| `bouncer.rule.outcome` | string | Outcome applied (e.g. `block`) |
+| `bouncer.policy.priority` | string | `immutable`, `strict`, or `flexible` from frontmatter |
+| `bouncer.path` | string enum | `path_a` or `path_b` — which deployment path enforced the control |
+
+**GenAI SemConv attributes to use where applicable:**
+
+| SemConv attribute | Use case |
+| --- | --- |
+| `gen_ai.system` | The LLM system the agent is running on |
+| `gen_ai.operation.name` | The agent operation being guarded |
+| `gen_ai.agent.id` | Agent identifier (when available from the framework) |
+
+Resolvers **MUST** use `gen_ai.*` SemConv attributes when an existing attribute covers the semantic. Resolvers **MUST NOT** define a `bouncer.*` attribute for something SemConv already owns.
+
+The `bouncer.resolve` span **SHOULD** be a child of the active agent or framework span so traces connect end-to-end. Resolvers **MUST** document how to wire parent context if the framework does not propagate it automatically.
+
+#### Log event model
+
+Structured log events fire on guardrail activation only — not on every resolver invocation.
+
+**Log event name:** `bouncer.guardrail.fired`
+
+**Minimum required fields:**
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `timestamp` | ISO 8601 | When the guardrail fired |
+| `bouncer.rule.name` | string | Control name |
+| `bouncer.rule.subject` | string | Subject that triggered it |
+| `bouncer.rule.condition` | string | Condition matched |
+| `bouncer.rule.outcome` | string | Outcome applied |
+| `bouncer.policy.file` | string | Source policy file |
+| `bouncer.session.id` | string | Agent session identifier |
+| `bouncer.agent.id` | string | Agent identifier |
+
+Log events **SHOULD** be attached to the active `bouncer.resolve` span via `span.add_event("bouncer.guardrail.fired", attributes)` when a span is present.
+
+#### Privacy requirement
+
+Input content (prompt text, tool results, retrieved content) **MUST NOT** be included in log events or span attributes by default. Resolvers **MAY** provide an opt-in `bouncer.debug.include_content` configuration flag. When enabled, the resolver **MUST** document that content may appear in telemetry and **MUST** warn that this flag **MUST NOT** be enabled in production.
+
+#### Resolver documentation requirements
+
+* Resolvers that support telemetry **MUST** document which attributes they emit
+* Resolvers that do not support telemetry **MUST** document this explicitly
+* Resolvers **MUST** use the `bouncer.*` namespace for resolver-specific attributes not covered by SemConv
+
+#### Relationship to OTel GenAI SIG
+
+The `bouncer.*` attribute namespace is intended as a contribution to the GenAI SIG conversation, not a permanent fork. Attributes that SemConv eventually ratifies for guardrail and policy evaluation semantics **SHOULD** replace the corresponding `bouncer.*` attributes in a future spec version. Resolvers **SHOULD** be designed so that attribute key renaming is the only migration required when that happens.
+
+---
+
 ## 9. Non-Goals
 
 Bouncer files **MUST NOT** define:
@@ -782,7 +867,7 @@ Bouncer is designed to support a community repository of reusable, domain-specif
 
 Community contributions **MUST** comply with the scope discipline defined in Section 9. Bouncer files are **safety and compliance artifacts only**.
 
-The Bouncer specification and ecosystem are designed to complement emerging agent observability standards including OpenTelemetry GenAI Semantic Conventions. Bouncer defines what rules exist and when they fire. Observability layers define whether they fired and what happened.
+The Bouncer specification and ecosystem are designed to complement emerging agent observability standards including OpenTelemetry GenAI Semantic Conventions. Bouncer defines what rules exist and when they fire. Section 8.4 defines the normative telemetry model — the span and log event structure resolvers SHOULD emit so that observability layers can surface whether guardrails fired and what happened.
 
 ---
 


### PR DESCRIPTION
Closes #33

## Summary

- Bumps the spec from v0.5 to v0.7
- Adds **Section 8.4 Resolver Observability** — the normative telemetry model for resolvers, including the `bouncer.resolve` span model, `bouncer.guardrail.fired` log event model, a normative closed enumeration for `bouncer.execution_point`, split version captures (`bouncer.policy.version` and `bouncer.policy.spec`), privacy opt-in requirement, and resolver documentation requirements
- Updates **Section 4.4** (`log` outcome) with a cross-reference to Section 8.4
- Updates **Section 14** to point to Section 8.4 as the normative OTel telemetry model
- Updates README and SECURITY.md to reflect v0.7 and the new telemetry section
- Fixes markdown linting issues in README and SECURITY.md (MD032, MD034, MD036, MD040)

## Decisions captured in this PR

- `bouncer.execution_point` is a **normative closed enumeration**: `pre_invocation`, `tool_call`, `agent_handoff`, `post_generation` — resolvers MUST NOT emit values outside this set
- Two version captures on the span: `bouncer.policy.version` (from `version` frontmatter field) and `bouncer.policy.spec` (from `spec` URI frontmatter field)
- `bouncer.composition.depth` (multi-agent nesting depth) is **deferred** until the spec defines a normative multi-agent composition model

## Test plan

- [x] Review Section 8.4 against the decisions documented in issue #33
- [x] Confirm `bouncer.execution_point` enumeration values match issue #33
- [x] Confirm Section 4.4 cross-reference reads correctly in context
- [x] Confirm Section 14 update is consistent with Section 8.4 language
- [x] Confirm README version references are correct (v0.7)
- [x] Confirm SECURITY.md version pin example is correct (v0.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)