### PR TITLE
Update root README: resolver link and directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ That's it. No code required. The LLM applies the controls directly.
 
 ### 3. (Optional) Wire the reference resolver
 
-For deterministic enforcement in production pipelines, integrate the reference resolver into your agent pipeline. See [SPEC.md](./SPEC.md) Section 8.2 for the integration pattern.
+For deterministic enforcement in production pipelines, integrate the reference resolver into your agent pipeline. See the [resolver README](./resolver/README.md) for installation and usage, and [SPEC.md](./SPEC.md) Section 8.2 for the integration pattern.
 
 ---
 
@@ -163,6 +163,10 @@ bouncer-md/
 │   ├── prompt-injection.bouncer.md       # Prompt injection defense
 │   ├── secret-protection.bouncer.md      # Secret and credential protection
 │   └── tool-execution-safety.bouncer.md  # Tool execution guardrails
+├── resolver/
+│   └── README.md                         # Reference resolver — install, usage, IR schema
+├── harness/
+│   └── PLAN.md                           # Agent test harness development plan
 ├── tests/
 │   ├── README.md                         # Testing guide
 │   ├── adversarial/                      # Attack prompt inputs, one file per threat
@@ -171,6 +175,7 @@ bouncer-md/
 ├── .gitignore
 ├── README.md
 ├── CONTRIBUTING.md
+├── SECURITY.md
 └── LICENSE
 ```
 


### PR DESCRIPTION
## Summary
- **Quick Start Step 3**: adds a direct link to `resolver/README.md` alongside the existing SPEC.md reference — the resolver existed but was never linked from the root README
- **Repository Structure**: adds `resolver/` and `harness/` entries (both exist on disk but were missing from the tree), and adds `SECURITY.md`

## What was wrong
- `resolver/README.md` was unreachable from the root README; users following the Quick Start had no path to installation/usage docs
- The repo structure diagram was stale — `resolver/`, `harness/`, and `SECURITY.md` were all absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)