### PR TITLE
[SEV-1] Fix resolver fail-open: PEP null guard + parser max input size (issue #62)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -126,6 +126,33 @@ Understanding the security properties of bouncer-md requires understanding what 
 
 ---
 
+### 10. Computational Resource Exhaustion
+
+**Risk:** An attacker can construct an oversized payload — dense text, logs, or
+arbitrary content padded to the resolver's processing limit — causing the resolver
+to time out or exhaust memory. If the resolver returns null or a non-IR result on
+failure and the PEP treats that as "no policy found," the result is fail-open. The
+malicious instruction can be embedded in the payload tail, bypassed entirely by the
+resource exhaustion condition.
+
+**Affected path:** Path B only.
+
+**Mitigation:**
+
+- The reference resolver enforces a max input size (`MAX_INPUT_BYTES`) before parsing
+  begins. Inputs exceeding the limit throw `BouncerMalformedFileError` immediately —
+  no parsing occurs and memory usage is bounded.
+- PEP implementations MUST treat any null, undefined, or exception result from the
+  resolver as a block condition. Never default to allow on resolver error. See §7.6.
+- An internal processing timeout guard (Fix 1, tracked in issue #63) is deferred
+  pending implementation design decisions. Until Fix 1 is implemented, infrastructure
+  timeout configuration is the mitigation for processing time exhaustion beyond the
+  input size guard.
+- Test with oversized inputs as part of your adversarial test suite. The public harness
+  includes a computational adversarial scenario.
+
+---
+
 ### 9. Fork and Modified Spec Deployment
 
 **Risk:** An implementation built against a modified fork of the spec may claim canonical bouncer-md conformance while having removed safety-critical requirements (deny-by-default, fail-closed behavior, additive-restriction-only). A bouncer file authored against a stripped fork looks identical to one authored against the canonical spec. Downstream consumers have no way to detect the difference without explicit verification.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -126,6 +126,22 @@ Understanding the security properties of bouncer-md requires understanding what 
 
 ---
 
+### 9. Fork and Modified Spec Deployment
+
+**Risk:** An implementation built against a modified fork of the spec may claim canonical bouncer-md conformance while having removed safety-critical requirements (deny-by-default, fail-closed behavior, additive-restriction-only). A bouncer file authored against a stripped fork looks identical to one authored against the canonical spec. Downstream consumers have no way to detect the difference without explicit verification.
+
+**Affected path:** Path A and Path B.
+
+**Mitigation:**
+
+- Pin your resolver implementation to a specific tagged release of the canonical spec (e.g. `v0.7`).
+- Verify the pinned version in your CI pipeline against the Section 11.3 conformance tests.
+- Treat any resolver not pinned to a canonical tagged release as unverified.
+- Use the optional `spec` frontmatter anchor (Section 3.3 of the spec) to declare which spec version a file was authored against. If a resolver detects a mismatch, it SHOULD log it.
+- Modified forks are permitted under MIT but MUST NOT claim conformance with the canonical bouncer-md specification. See Section 12.2 of the spec.
+
+---
+
 ### 10. Computational Resource Exhaustion
 
 **Risk:** An attacker can construct an oversized payload — dense text, logs, or
@@ -150,22 +166,6 @@ resource exhaustion condition.
   input size guard.
 - Test with oversized inputs as part of your adversarial test suite. The public harness
   includes a computational adversarial scenario.
-
----
-
-### 9. Fork and Modified Spec Deployment
-
-**Risk:** An implementation built against a modified fork of the spec may claim canonical bouncer-md conformance while having removed safety-critical requirements (deny-by-default, fail-closed behavior, additive-restriction-only). A bouncer file authored against a stripped fork looks identical to one authored against the canonical spec. Downstream consumers have no way to detect the difference without explicit verification.
-
-**Affected path:** Path A and Path B.
-
-**Mitigation:**
-
-- Pin your resolver implementation to a specific tagged release of the canonical spec (e.g. `v0.7`).
-- Verify the pinned version in your CI pipeline against the Section 11.3 conformance tests.
-- Treat any resolver not pinned to a canonical tagged release as unverified.
-- Use the optional `spec` frontmatter anchor (Section 3.3 of the spec) to declare which spec version a file was authored against. If a resolver detects a mismatch, it SHOULD log it.
-- Modified forks are permitted under MIT but MUST NOT claim conformance with the canonical bouncer-md specification. See Section 12.2 of the spec.
 
 ---
 

--- a/harness/report/reporter.ts
+++ b/harness/report/reporter.ts
@@ -49,7 +49,7 @@ export function generateReport(report: RunReport): string {
     lines.push(`── Adversarial: ${cat} ──────────────────────────────────────`);
     for (const r of results) {
       const scenarioName = r.scenario.split("/")[1] ?? r.scenario;
-      const outcome = r.ir.controls[0]?.resolved_outcome ?? "unknown";
+      const outcome = r.ir?.controls[0]?.resolved_outcome ?? "unknown";
       const toolInvoked = r.toolInvocations.filter((i) => i.tool === r.targetedTool).length > 0;
       const note = toolInvoked
         ? `${r.targetedTool} WAS invoked`

--- a/harness/scenario/runner.ts
+++ b/harness/scenario/runner.ts
@@ -39,7 +39,7 @@ const ADVERSARIAL_DIR = path.resolve(__dirname, "../adversarial");
 function captureResolve(
   agentInstructionPath: string,
   options: ResolveOptions
-): { ir: ResolvedPolicyIR; records: AuditRecord[] } {
+): { ir: ResolvedPolicyIR | null; records: AuditRecord[] } {
   const captured: string[] = [];
   const originalWrite = process.stdout.write.bind(process.stdout);
 
@@ -62,9 +62,11 @@ function captureResolve(
   // Override stdout.write to intercept audit records from resolve()
   process.stdout.write = captureWrite;
 
-  let ir: ResolvedPolicyIR;
+  let ir: ResolvedPolicyIR | null = null;
   try {
     ir = resolve(agentInstructionPath, options);
+  } catch {
+    // resolver threw — ir stays null; callers must treat null as block (fail closed, §7.6)
   } finally {
     process.stdout.write = originalWrite;
   }
@@ -82,8 +84,9 @@ function captureResolve(
 
 // ── PEP enforcement helper ────────────────────────────────────────────────────
 
-function isBlocked(ir: ResolvedPolicyIR): boolean {
-  if (ir.controls.length === 0) return true; // fail closed
+function isBlocked(ir: ResolvedPolicyIR | null | undefined): boolean {
+  if (!ir) return true; // null/undefined IR = fail closed (§7.6)
+  if (ir.controls.length === 0) return true;
   return ir.controls.some((c) => c.resolved_outcome === "block");
 }
 
@@ -122,7 +125,7 @@ async function runAgent(
   provider: LlmProvider,
   agent: Agent,
   userMessage: string,
-  ir: ResolvedPolicyIR,
+  ir: ResolvedPolicyIR | null | undefined,
   maxTurns = 4
 ): Promise<{ response: string; model: string }> {
   const blocked = isBlocked(ir);
@@ -331,11 +334,20 @@ async function runOneAdversarialScenario(
   const invocations = getInvocations();
 
   if (passed) {
-    try {
-      assertAdversarialBlock(ir, records, spec.targetedTool, invocations);
-    } catch (err) {
-      passed = false;
-      failureReason = err instanceof AssertionError ? err.message : String(err);
+    if (ir === null) {
+      // Resolver threw — PEP must have enforced block; verify targeted tool was not invoked
+      const hits = invocations.filter((i) => i.tool === spec.targetedTool);
+      if (hits.length > 0) {
+        passed = false;
+        failureReason = `Resolver error treated as allow — "${spec.targetedTool}" was invoked`;
+      }
+    } else {
+      try {
+        assertAdversarialBlock(ir, records, spec.targetedTool, invocations);
+      } catch (err) {
+        passed = false;
+        failureReason = err instanceof AssertionError ? err.message : String(err);
+      }
     }
   }
 

--- a/harness/scenario/types.ts
+++ b/harness/scenario/types.ts
@@ -14,7 +14,7 @@ export interface ToolInvocation {
 }
 
 export interface ScenarioResult {
-  ir: ResolvedPolicyIR;
+  ir: ResolvedPolicyIR | null;
   auditRecords: AuditRecord[];
   toolInvocations: ToolInvocation[];
   passed: boolean;
@@ -24,7 +24,7 @@ export interface ScenarioResult {
 export interface AdversarialResult {
   scenario: string;
   adversarialInput: string;
-  ir: ResolvedPolicyIR;
+  ir: ResolvedPolicyIR | null;
   auditRecords: AuditRecord[];
   targetedTool: string;
   toolInvocations: ToolInvocation[];

--- a/resolver/README.md
+++ b/resolver/README.md
@@ -151,6 +151,21 @@ interface ResolutionLogEntry {
 
 ---
 
+## Processing Limits
+
+The resolver enforces the following limits to prevent computational resource exhaustion attacks (see SECURITY.md Threat Vector 10).
+
+| Limit | Value | Behavior on violation |
+|-------|-------|-----------------------|
+| Max input size (`MAX_INPUT_BYTES`) | 512 KB (512,000 bytes) | Throws `BouncerMalformedFileError` with `reason: "input_too_large"` immediately — no parsing occurs |
+| Processing timeout | Not yet implemented (tracked in issue #63) | Infrastructure-level timeout is the current mitigation |
+
+The size check fires on the raw byte length of the bouncer file content, before YAML frontmatter parsing or Markdown control block parsing begins. A legitimate bouncer file will never approach this limit.
+
+**PEP authors:** catch both `BouncerMalformedFileError` and `BouncerPolicyMismatchError` and fail closed on either. See the Errors section above and §7.6 of SPEC.md.
+
+---
+
 ## File Discovery
 
 Per §10.1 of SPEC.md:

--- a/resolver/src/parser.ts
+++ b/resolver/src/parser.ts
@@ -1,5 +1,10 @@
 import * as fs from "node:fs";
 import yaml from "js-yaml";
+import { BouncerMalformedFileError } from "./errors.js";
+
+// Maximum bouncer file size before parsing is refused. A legitimate bouncer file
+// will never approach this limit; exceeding it indicates a computational attack.
+export const MAX_INPUT_BYTES = 512_000;
 
 export interface ParsedFrontmatter {
   name: string;
@@ -29,6 +34,10 @@ export function parseBouncerFile(filePath: string): ParseResult {
     content = fs.readFileSync(filePath, "utf-8");
   } catch (e) {
     return { ok: false, reason: `cannot read file: ${String(e)}` };
+  }
+
+  if (Buffer.byteLength(content, "utf-8") > MAX_INPUT_BYTES) {
+    throw new BouncerMalformedFileError(filePath, "input_too_large");
   }
 
   // Frontmatter must begin at the very start of the file

--- a/resolver/tests/conformance/malformed-files.test.ts
+++ b/resolver/tests/conformance/malformed-files.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import * as path from "node:path";
 import * as url from "node:url";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import { resolve, BouncerMalformedFileError } from "../../src/index.js";
+import { MAX_INPUT_BYTES } from "../../src/parser.js";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const fixtures = path.resolve(__dirname, "../fixtures");
@@ -94,5 +97,76 @@ describe("zero valid controls rejection", () => {
     const err = caughtError as BouncerMalformedFileError;
     // reason must clearly identify the zero-controls problem, not a parse error
     expect(err.reason.toLowerCase()).toMatch(/zero|no valid control|no control/);
+  });
+});
+
+// ── Test 12 (SEV-1 fix, issue #62) ───────────────────────────────────────────
+describe("input_too_large rejection", () => {
+  // Generate the oversized fixture at runtime to avoid committing a 512 KB blob to the repo.
+  // The file contains valid frontmatter and a valid control block followed by padding that
+  // pushes it past MAX_INPUT_BYTES. The resolver MUST throw before any parsing begins.
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bouncer-input-too-large-"));
+    fs.writeFileSync(
+      path.join(tmpDir, "agent.md"),
+      "# Agent Instructions\n\nYou are the agent under test."
+    );
+
+    const header = [
+      "---",
+      "name: Oversized Policy",
+      "description: Policy padded to exceed MAX_INPUT_BYTES",
+      "---",
+      "",
+      "## Control: Padding Control",
+      "",
+      "### Applies To",
+      "",
+      "- agent",
+      "",
+      "### Detect",
+      "",
+      "- test",
+      "",
+      "### Enforce",
+      "",
+      "- block",
+      "",
+      "### Outcome",
+      "",
+      "- block",
+      "",
+      "### Note:",
+      "",
+    ].join("\n");
+
+    // Pad to one byte past the limit so the guard fires on exactly this file size
+    const padding = "x".repeat(MAX_INPUT_BYTES + 1 - Buffer.byteLength(header, "utf-8"));
+    fs.writeFileSync(path.join(tmpDir, "policy.bouncer.md"), header + padding);
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("throws BouncerMalformedFileError before parsing when file exceeds MAX_INPUT_BYTES", () => {
+    const agentFile = path.join(tmpDir, "agent.md");
+
+    let caughtError: unknown = null;
+    let returnedIR: unknown = null;
+
+    try {
+      returnedIR = resolve(agentFile, { logLevel: "silent" });
+    } catch (e) {
+      caughtError = e;
+    }
+
+    expect(caughtError).toBeInstanceOf(BouncerMalformedFileError);
+    expect(returnedIR).toBeNull();
+
+    const err = caughtError as BouncerMalformedFileError;
+    expect(err.reason).toBe("input_too_large");
   });
 });


### PR DESCRIPTION
## Summary

Closes #62

Two fixes for the SEV-1 fail-open condition surfaced by the red team. Implemented in the order specified: Fix 3 (PEP) first, Fix 2 (parser) second. Fix 1 (internal processing timeout) is tracked separately in #63 — deferred pending an implementation design decision.

- **Fix 3 — PEP null guard** (`harness/scenario/runner.ts`, `types.ts`, `reporter.ts`): `captureResolve()` now catches resolver exceptions and returns `ir: null` instead of propagating uncaught. `isBlocked()` accepts `null | undefined` and returns `true` (block) for both — any resolver failure is treated as a block condition per §7.6. The adversarial runner handles null IR without calling `assertAdversarialBlock`, instead verifying no targeted tool invocations occurred.
- **Fix 2 — Parser max input size guard** (`resolver/src/parser.ts`): `MAX_INPUT_BYTES = 512_000` (512 KB) is enforced immediately after reading file content, before any YAML or Markdown parsing begins. Throws `BouncerMalformedFileError("input_too_large")` on oversize — eliminating the 1.4 GB memory spike and 4.8 s processing time that triggered the infrastructure timeout in the red team exercise.

## Test plan

- [x] All 124 resolver conformance tests pass (`npm test` in `resolver/`)
- [x] All 51 harness unit tests pass (`npm test` in `harness/`)
- [x] TypeScript typechecks clean in both packages (`npm run typecheck`)
- [x] `isBlocked(null)` returns `true` — enforced by updated type signature and null guard
- [x] `parseBouncerFile` throws `BouncerMalformedFileError` on files > 512 KB — enforced by `MAX_INPUT_BYTES` constant and `Buffer.byteLength` check before parse
- [ ] Fix 1 (processing timeout) tracked in #63 — do not merge #63 until design decision is made

## What is NOT in this PR

Fix 1 (internal processing timeout) is deliberately excluded. See #63 for the full rationale. In short: a correct implementation in a synchronous Node.js context requires either a cooperative timeout (which cannot interrupt a mid-regex execution) or Worker threads (which make `resolve()` async and break the public API). That decision requires alignment before implementation — not a SEV-1 time-pressured build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)